### PR TITLE
Update 4/1/2020 6:00 p.m.

### DIFF
--- a/ListSorted.cpp
+++ b/ListSorted.cpp
@@ -1,18 +1,22 @@
+// ListSorted.cpp (Implementation file for derived class)
 // uses an "Optimized" Bubble Sort technique sort the data within
 // the list, rather than modify link structure.
+
+#include "ListSorted.h"
+
 template <class Type>
-void List<Type>::sortLinkedList(string field)
+void ListSorted<Type>::sortLinkedList(string field)
 {
     nodeType<Type> *curr;               // local current pointer
-	nodeType<Type> *next;               // local pointer always previous to curr
+    nodeType<Type> *next;               // local pointer always previous to curr
     bool swapped = true;                // assume swapped is true to enter the outer loop
-    for(int i = 0; swapped && i < count; i++)  /// SOMETHING 2 X SPECIAL HERE!
+    for(int i = 0; swapped && i < List<Type>::count; i++)  /// SOMETHING 2 X SPECIAL HERE!
     {
     	// keeps track of current pointer and the next adjacent pointer
-        curr = first;                   // assigns first to local curr pointer
-        next = first->link;             // next is the pointer after curr
+        curr = List<Type>::first;                   // assigns first to local curr pointer
+        next = List<Type>::first->link;             // next is the pointer after curr
     	swapped = false;                // reset flag to assume no swaps will happen
-        for(int j = 0; j < count - i - 1; j++)  // optimized inner loop
+        for(int j = 0; j < List<Type>::count - i - 1; j++)  // optimized inner loop
         {
             if(field == "GPA")          // if the key field was GPA
             {
@@ -20,9 +24,11 @@ void List<Type>::sortLinkedList(string field)
                 if (curr->stuRecord.fGpa < next->stuRecord.fGpa) // GPA's descending
                     swapped = swapData(curr->stuRecord, next->stuRecord);   // swap data
             }
-            else                        // the name field should be sorted in ascending order
+            else                        // the name field will be sorted in ascending order
             {
                 // if structure checks for names ascending order
+                if (curr->stuRecord.name < next->stuRecord.name) // Name's descending
+                    swapped = swapData(curr->stuRecord, next->stuRecord);   // swap data
                 // same swap as in line 20 above
             }
             curr = curr->link;          // advance curr ptr
@@ -33,7 +39,7 @@ void List<Type>::sortLinkedList(string field)
 
 // swapData used to exchange all data between nodes
 template <class Type>
-bool List<Type>::swapData(Type & currRec, Type & prevRec)
+bool ListSorted<Type>::swapData(Type & currRec, Type & prevRec)
 {
     Type tempRec = currRec;             // save current record
     currRec = prevRec;                  // assign previous record to currRec


### PR DESCRIPTION
I renamed it from "listsorted.cpp" to "ListSorted.cpp" for Implementation/Function call regions in the program.
I added "List<Type>::" in front of some of our pointers that are protected in "List.h" ("first"  & "count"). This is so that there is reference to them.